### PR TITLE
fix: Correct redirection to k-thread properties slide in activity 2

### DIFF
--- a/src/activities/act-2.qmd
+++ b/src/activities/act-2.qmd
@@ -140,7 +140,7 @@ As stated on the [week-2 slides](weeks/week-2), there are different ways to get 
 
 - To detect processes or kernel threads, the algorithm is "trivial", the idea is:
     1) List the contents of the proc directory, and filter the ones that are digits (pids/tgid).
-    2) Now you have to filter if they're a process o kernel thread. We recommend you to [apply the mask](https://www.youtube.com/watch?v=AHiepE54l88) that the [htop code applies to the flags content](/weeks/week-2.html#/properties-of-procfs-kernel-threads) to see if they are a kernel thread [^1].
+    2) Now you have to filter if they're a process or kernel thread. We recommend you to [apply the mask](https://www.youtube.com/watch?v=AHiepE54l88) that the [htop code applies to the flags content](/weeks/week-2.html#/properties-of-procfs-kernel-threads) to see if they are a kernel thread [^1].
 	- If it's a kernel thread, add it to the list and stop analyzing.
 	- If it's a process, add it, but be aware that can have threads spawned (next point will explain this).
 - To detect threads, it's a little bit more complicated, you should:

--- a/src/activities/act-2.qmd
+++ b/src/activities/act-2.qmd
@@ -287,7 +287,7 @@ Keep in mind that the first two items (tests and linter) can be automatically ve
 2.  It is **forbidden to make python execute a Linux command** that will provide the information about processes.
 3.  The process information needed can **only be obtained by reading the contents of `/proc` and parsing it out** (remember you have [helpers](https://docs.amsa.lol/_apidoc/amsatop.utils.html) for that).
 4.  Make sure the tests are passing on the [Ubuntu VM](https://amsa.lol/#resources), we'll pass them on the VM too.
-5.  If you are a group of 2, both of you must contribute to the repoistory with at least 1 commit.
+5.  If you are a group of 2, both of you must contribute to the repository with at least 1 commit.
 
 ## 9. Resources
 

--- a/src/activities/act-2.qmd
+++ b/src/activities/act-2.qmd
@@ -140,7 +140,7 @@ As stated on the [week-2 slides](weeks/week-2), there are different ways to get 
 
 - To detect processes or kernel threads, the algorithm is "trivial", the idea is:
     1) List the contents of the proc directory, and filter the ones that are digits (pids/tgid).
-    2) Now you have to filter if they're a process o kernel thread. We recommend you to [apply the mask](https://www.youtube.com/watch?v=AHiepE54l88) that the [htop code applies to the flags content](weeks/week-2.html#/properties) to see if they are a kernel thread [^1].
+    2) Now you have to filter if they're a process o kernel thread. We recommend you to [apply the mask](https://www.youtube.com/watch?v=AHiepE54l88) that the [htop code applies to the flags content](/weeks/week-2.html#/properties-of-procfs-kernel-threads) to see if they are a kernel thread [^1].
 	- If it's a kernel thread, add it to the list and stop analyzing.
 	- If it's a process, add it, but be aware that can have threads spawned (next point will explain this).
 - To detect threads, it's a little bit more complicated, you should:


### PR DESCRIPTION
-  Changed link from "weeks/week-2#properties" to "/weeks/week-2.html#/properties-of-procfs-kernel-threads" (absolute path)
- Corrected "repoistory" to "repository" in section 8 of Activity 2
- Corrected "process o kernel" to "process or kernel" in section 5 of Activity 2